### PR TITLE
Add functionality to disable end turn button

### DIFF
--- a/Content/Cards/Courage/LessWildGrowth.uasset
+++ b/Content/Cards/Courage/LessWildGrowth.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:92cd351d568e15841efa32fe64d5e3e7a25983112fcfcd7fafa87265684692d0
-size 85836
+oid sha256:fb8cdd2c63091e6584bd344d02ec01aad08113775da2227694f35e3d7fc03c7a
+size 85884

--- a/Content/Game/PC_PlayerController.uasset
+++ b/Content/Game/PC_PlayerController.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b848a97dbe6d43ceac4868d55868bc839cb1a815147fd0573cf2e7d5299173ab
-size 294392
+oid sha256:869809bb7759f1fddf33dc69b54b0dcb683fd793b753e20668d5c68c84a96b5b
+size 291121

--- a/Content/UI/HUD.uasset
+++ b/Content/UI/HUD.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4c0ab7268fc9750e4dc522abbc82c1678aae4f29f4d464210e6f94672639edc0
-size 75690
+oid sha256:1fad57c8855b03d9ab789253f9defa33ce8d09d52a051fcd4e84c9bb2a48b0ad
+size 88017


### PR DESCRIPTION
Game now disables and reenables the end turn button while the enemy turn is taking place, this fixes #96.