### PR TITLE
Fix logic surrounding enemy death

### DIFF
--- a/Content/Enemy/AxeDemon.uasset
+++ b/Content/Enemy/AxeDemon.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ec9c2cbda4a430840152f1de934a1ffa78b456fca19559abe9615a7a782701bb
-size 39261
+oid sha256:3aaae1eed586b38c593d9432882229bbeefbc2571fa806fc48b014f5cc4eeebe
+size 37741

--- a/Content/Enemy/EnemyBase.uasset
+++ b/Content/Enemy/EnemyBase.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:911d22b30052b85b70f92b875fafb7a5a743b5ba78ea9774a2e4b00136eef94f
-size 370697
+oid sha256:a9873bc4f102d4744f0c89da3805486cf2b80ae4003f4cd3fc95b177a529bbb0
+size 369108

--- a/Content/Enemy/EnemyBase.uasset
+++ b/Content/Enemy/EnemyBase.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fd79168d7eff8db35814cbec3f04f7dabccf8fff18e6654a6ea3522d55e4a348
-size 367164
+oid sha256:911d22b30052b85b70f92b875fafb7a5a743b5ba78ea9774a2e4b00136eef94f
+size 370697

--- a/Content/Enemy/EnemyBase.uasset
+++ b/Content/Enemy/EnemyBase.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a9873bc4f102d4744f0c89da3805486cf2b80ae4003f4cd3fc95b177a529bbb0
-size 369108
+oid sha256:08ea5c203f19bb0df7e184b7716fbcce0c16b65f88d407a0d0caa3936cf81684
+size 389938

--- a/Content/Enemy/Imp.uasset
+++ b/Content/Enemy/Imp.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7fe3413b933062c9aa5cb0c273075b51565bc9e929b378564e7210ec32bde0c7
-size 38944
+oid sha256:5d812d5a2dbd39bd5db23db02c73363fb06417370461ad7ee903630c39a98dc1
+size 36942

--- a/Content/Enemy/KijoMomiji.uasset
+++ b/Content/Enemy/KijoMomiji.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bb7db224569bb594a7b76148da9ba832ecf9332a1bfd03c7a1ef75c34dfb95ee
-size 38776
+oid sha256:cbbc7f637a2e4a72c895949a128429d2c5c84fe001a0087e4b6734c27fbe734b
+size 36871

--- a/Content/Enemy/MartialHero.uasset
+++ b/Content/Enemy/MartialHero.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:755a7e57822b79436da2d2fa9639804cb86826ea748f7eb435f775ceffa9a0c3
-size 39084
+oid sha256:b4ce6bd2b5ae714dc0bea799874e63988624148c7bc226cf5b1f1a3e33da1229
+size 37179

--- a/Content/Enemy/MaskedWarrior.uasset
+++ b/Content/Enemy/MaskedWarrior.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a81dd5fdf35991fdb983cceb5d099e2f87c088b85b666c745513335b13a1dd79
-size 38976
+oid sha256:ac2ea80403ea5440221f16a0ba285ce17d42ad510ca4c77b9faf2ab15f5b2432
+size 37164

--- a/Content/Enemy/Tengu.uasset
+++ b/Content/Enemy/Tengu.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cdb4e33a86d2e967f71d3a4cf45078800ccc7154880feb272d59581d5f390097
-size 38830
+oid sha256:b79104d116786a7eb790f35f0484af5283c37108a838cf4fcc87cb492cf0c142
+size 37061

--- a/Content/Game/MacroLibrary.uasset
+++ b/Content/Game/MacroLibrary.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8b30b2cc0562afa517d20ff784abafe4797d3430b13b6dc92dab01de14993302
-size 87289
+oid sha256:4281cb185bad6adf2062d3db84792e0124297dd8ab58de5dbcfcc1b61fd74741
+size 129142

--- a/Content/Game/PC_PlayerController.uasset
+++ b/Content/Game/PC_PlayerController.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:54c99021ca4be2039f85d129a7c13dc3e6846d6aa3a2e876725f8cd034c77f63
-size 490507
+oid sha256:d91c9a504d966d449501ac29f1c91dc7b8bac282647018e914985fab0d13946f
+size 493576


### PR DESCRIPTION
Creates a new macro to remove all dead enemies from an array, used after getting all actors of class to do all target selection. Additionally, modifies the logic surrounding end turn and enemy attacks to utilize this macro to prevent undesired behavior.

This fixes #155 and fixes #162.