### PR TITLE
Fix yokai save data errors

### DIFF
--- a/Content/Game/GI_Momotaro.uasset
+++ b/Content/Game/GI_Momotaro.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b1533ba19bbf4446b4ef92b41c1896fa6184c8c83f9ccf03ac3375f85f36e03a
-size 45283
+oid sha256:3cbfa90683e71c35f81c2a5d2da8e0128c12f9ed8812774be5a5137a638fe0fe
+size 60699


### PR DESCRIPTION
Yokai save data was not being reset to it's default values for health. Additionally, ensures that the deck struct array is now being cleared.

Closes #206